### PR TITLE
CIR-2157 Remove testReport

### DIFF
--- a/run-specs.sh
+++ b/run-specs.sh
@@ -3,4 +3,4 @@
 BROWSER=$1
 ENVIRONMENT=$2
 
-sbt clean -Dbrowser="${BROWSER:=chrome}" -Denvironment="${ENVIRONMENT:=local}" "testOnly uk.gov.hmrc.test.ui.specs.*" testReport
+sbt clean -Dbrowser="${BROWSER:=chrome}" -Denvironment="${ENVIRONMENT:=local}" "testOnly uk.gov.hmrc.test.ui.specs.*"


### PR DESCRIPTION
sbt-test-report was removed in the previous PR but we still had an sbt testReport being executed which Jenkins picked up on
<img width="1109" alt="image" src="https://github.com/user-attachments/assets/02aa7600-8d10-481d-9d33-d5dabdd6a090" />
